### PR TITLE
fix Bad Smells

### DIFF
--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractEntityListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractEntityListener.java
@@ -84,7 +84,7 @@ public final class PlayerInteractEntityListener extends Queue implements Listene
         int y = frameLocation.getBlockY();
         int z = frameLocation.getBlockZ();
 
-        String transactingChestId = frameLocation.getWorld().getUID().toString() + "." + x + "." + y + "." + z;
+        String transactingChestId = frameLocation.getWorld().getUID() + "." + x + "." + y + "." + z;
         String loggingChestId = user.toLowerCase(Locale.ROOT) + "." + x + "." + y + "." + z;
         int chestId = Queue.getChestId(loggingChestId);
         if (chestId > 0) {


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
# Repairing Code Style Issues
* UnnecessaryToStringCall (1)
